### PR TITLE
QWT-5: improve README and add -f

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,109 @@ Well done! You'll need this to set up Qwitch.
 
 Now you can use Qwitch in the terminal and it will ask you for this token in due time. It will also prompt you to give it access to a few information from your Twitch account. To do so it will automatically open your web browser, you'll need to accept, and then copy and paste the URL of the page back to Qwitch.
 
+## How to use
+
+Here are a few examples of how to achieve certain tasks with Qwitch:
+### See which streamers you follow are live now
+
+This is rather simple, simply enter the command below:
+```
+qwitch -s
+```
+The option `-s` is short for `--streams`. Qwitch will get the list of streamers you follow and display which ones are live now, with information about their stream.
+
+### List the streamers you follow and their channel name
+
+This is rather simple, simply enter the command below:
+```
+qwitch -f
+```
+The option `-f` is short for `--follows`. Qwitch will get the list of streamers you follow and display information about their channel. **Most important information is their channel name displayed in red, which Qwitch needs when you search for their videos or streams.**
+
+### Watch this streamer's live
+
+Say your favourite streamer is live and you want to watch their stream. Then all you'll need is the name of their channel. For example, if I want to watch Critical Role live, and I know the name of their channel is `criticalrole` then I use the following command to launch their livestream:
+```
+qwitch -s criticalrole
+```
+To know your streamer's channel name either use `qwitch -s`, if they are live then the channel name will be written in red. Otherwise, look at Twitch's link to their channel. In Critical Role's example it would be `https://twitch.tv/criticalrole` so their channel name is `criticalrole`.
+
+Alternatively you can list the streamers you follow with `qwitch -f` and the channel names will be displayed in red.
+
+### Watch this streamer's last video
+
+You can watch a streamer's last video with the `-l` option (short for `--last`), like so:
+```
+qwitch -l channelname
+```
+and replacing `channelname` by the streamer's actual channel name.
+
+### List a streamer's last 20 videos
+
+You can list a streamer's last 20 videos with the `-V` (or `--Videos`) option, like so:
+```
+qwitch -V channelname
+```
+and replacing `channelname` by the streamer's actual channel name.
+
+This will list the videos one by one, and ask you each time if you want to watch the video. Simply enter `y`, for yes, or `n`, for no, and hit <kbd>⏎ Enter</kbd>.
+
+### Search and watch a streamer's video
+
+To search and watch one of the streamer's last 20 videos, you can use the `-v` (short for `--vod`) either with a video ID or by using keywords from the video's title.
+
+A video ID can be obtained from the video's `twitch.tv` link (e.g. `https://twitch.tv/videos/524717693` the video ID is `524717693`), or after using `qwitch -V channelname` to list channelname's last 20 videos. Once the video ID is obtained you can watch it with:
+```
+qwitch -v <VIDEO_ID>
+```
+where `<VIDEO_ID>` has to be replaced with the actual video ID (e.g. `524717693`).
+
+To search for a video with a keyword(s), specify the keyword in quotation marks followed by the channel name. Like so:
+```
+qwitch -v "some keywords" channelname
+```
+This will search for a video with the title containing exactly `some keywords` in channelname's last 20 videos. The keywords you use have to be an exact match (up to letter case) because Twitch does not have any search engine to search for videos.
+
+### Adjust the video quality
+
+You can adjust a video's playback quality by telling Qwitch which video quality you want it to use. This is done by passing a video quality tag in the command (i.e. one of `160p`, `360p`, `480p`, `720p` or `1080p`) like so:
+```
+qwitch -s criticalrole 480p
+```
+This works with any qwitch command that can play a video.
+
+By default qwitch will use the best available quality. However, you can override this by setting the `default-stream` option in Qwitch's config file.
+
+## Qwitch's config file
+
+Qwitch's config file is located at `~/Library/Application Support/qwitch` and is named `config.json`. This file contains two entries:
+ - The first one contains information about you as a twitch user (this stays on your system, Qwitch doesn't collect any of your information), i.e. your tokens to log into twitch from the CLI
+ - The second one contains all the [Streamlink](https://streamlink.github.io) options that are needed to power Qwitch
+
+You can add Streamlink options to the second part of the config file in a JSON format. For example, you can add the `default-stream` Streamlink option to specify the default stream quality Qwitch should use. With this option, Qwitch's config file would look like
+```json
+[
+    {
+        "client_id": "qwer9tyuiopasdf0ghjkllzxcv4bnm",
+        "login": "username",
+        "scopes": [
+            "user:read:follows",
+            "user_read",
+            "user_subscriptions"
+        ],
+        "user_id": "12345678",
+        "expires_in": 4932814,
+        "access_token": "zxc6vbnm7asdfg3hjklqwert8yuiop",
+        "requested_at": 1682178117
+    },
+    {
+        "twitch-api-header": "Authorization=OAuth asdfghjkl4qwertyui9nbvc2qwerty",
+        "default-stream": "720p"
+    }
+]
+```
+More options for Streamlink can be found on their website. Options that are boolean, need to be added in JSON format, i.e. you will need to specify `True` or `False` as value for the key.
+
 ## Something wrong?
 
-If you find something's not right or you have some trouble setting things up, don't hesitate to create an issue on this repository and I'll do my best to help you.
+If you find something's not right or you have some trouble setting things up, don't hesitate to create an issue on Qwitch's GitHub repository and I'll do my best to help you.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,34 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qwitch"
-version = "2.1.0"
+version = "2.2.0"
 description = "Stream twitch in Quicktime."
 readme = "README.md"
 authors = [{ name = "Jean-Francois Vaduret", email = "jean.francois.vaduret@gmail.com" }]
+license = {file = "LICENSE"}
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "License :: OSI Approved :: MIT License",
+  "Environment :: Console",
+  "Intended Audience :: End Users/Desktop",
+  "Operating System :: MacOS",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Topic :: Internet :: WWW/HTTP",
+  "Topic :: Multimedia :: Sound/Audio",
+  "Topic :: Multimedia :: Video",
+  "Topic :: Utilities"
+]
 dependencies = [
     "requests",
     "streamlink"
 ]
 requires-python = ">=3.8"
+
+[project.urls]
+Source = "https://github.com/gencys/qwitch"
+Tracker = "https://github.com/gencys/qwitch/issues"

--- a/qwitch/api.py
+++ b/qwitch/api.py
@@ -21,7 +21,7 @@ def twitch_api_get(token, url):
     return res_get.json()
 
 def get_livestreams(token):
-    with open(config.home_dir + '/qwitch/cache', 'r', encoding='utf-8') as cache:
+    with open(config.home_dir + '/qwitch/config.json', 'r', encoding='utf-8') as cache:
             cache_json = json.loads(cache.read())
             config.debug_log('get_livestreams(): Config read:', cache_json)
     url = 'https://api.twitch.tv/helix/channels/followed?user_id=' + cache_json[0]['user_id']
@@ -45,6 +45,25 @@ def get_livestreams(token):
         print('\033[95mStreamer:\033[0m      ' + video['user_name'] + ' (\033[91m\033[1m' + video['user_login'] + '\033[0m)')
         print('\033[95mTitle:\033[0m         ' + video['title'])
         print('\033[95mGame/Category:\033[0m ' + video['game_name'])
+
+def get_follows(token):
+    with open(config.home_dir + '/qwitch/config.json', 'r', encoding='utf-8') as cache:
+            cache_json = json.loads(cache.read())
+            config.debug_log('get_livestreams(): Config read:', cache_json)
+    url = 'https://api.twitch.tv/helix/channels/followed?user_id=' + cache_json[0]['user_id']
+    res_get = twitch_api_get(token = token, url = url)
+    res_get = res_get['data']
+    first = True
+    for video in res_get:
+        if first:
+            print('Here are the channels you follow:\n(The channel name you will need is in red)\n')
+            first = False
+        else:
+            print('-------------------------------')
+        print('\033[95mChannel Display Name:\033[0m        ' + video['broadcaster_name'])
+        print('\033[95mChannel Name:\033[0m                ' + '\033[91m\033[1m' + video['broadcaster_login'] + '\033[0m')
+        date = video['followed_at'].replace('T', ' ').replace('Z', '')
+        print('\033[95mFollowed on:\033[0m                 ' + date)
 
 def get_channel_id(channel, token):
     url = 'https://api.twitch.tv/helix/users?login=' + channel

--- a/qwitch/config.py
+++ b/qwitch/config.py
@@ -10,8 +10,8 @@ DEBUG = False
 
 home_dir = os.path.expanduser('~')
 home_dir += '/Library/Application Support'
-if not os.path.exists(home_dir + '/qwitch/cache'):
-    os.makedirs(os.path.dirname(home_dir + '/qwitch/cache'), exist_ok=True)
+if not os.path.exists(home_dir + '/qwitch/config.json'):
+    os.makedirs(os.path.dirname(home_dir + '/qwitch/config.json'), exist_ok=True)
 
 def debug_log(*args):
     if DEBUG:
@@ -68,9 +68,9 @@ def validate_token(token: str):
     return res_get
 
 def write_streamlink_config():
-    if os.path.exists(home_dir + '/qwitch/cache'):
+    if os.path.exists(home_dir + '/qwitch/config.json'):
         token = ask_for_token(validate = True)
-        with open(home_dir + '/qwitch/cache', 'r', encoding='utf-8') as file:
+        with open(home_dir + '/qwitch/config.json', 'r', encoding='utf-8') as file:
             cache_json = json.loads(file.read())
         if len(cache_json) == 2:
             cache_json[1].update({'twitch-api-header': 'Authorization=OAuth ' + token})
@@ -80,14 +80,14 @@ def write_streamlink_config():
             }
             cache_json.append(config)
         config = cache_json[1]
-        with open(home_dir + '/qwitch/cache', 'w', encoding='utf-8') as file:
+        with open(home_dir + '/qwitch/config.json', 'w', encoding='utf-8') as file:
             json.dump(cache_json, file, ensure_ascii=False, indent=4)
         return config
     return False
 
 def check_streamlink_config():
     old_token = ''
-    with open(home_dir + '/qwitch/cache', 'r', encoding='utf-8') as file:
+    with open(home_dir + '/qwitch/config.json', 'r', encoding='utf-8') as file:
         content = json.loads(file.read())
         debug_log('Content of config:', content)
     if len(content) == 2:
@@ -115,7 +115,7 @@ def check_streamlink_config():
         break
     if old_token != token:
         content[1]['twitch-api-header'] = 'Authorization=OAuth ' + token
-        with open(home_dir + '/qwitch/cache', 'w', encoding='utf-8') as file:
+        with open(home_dir + '/qwitch/config.json', 'w', encoding='utf-8') as file:
             json.dump(content, file, ensure_ascii=False, indent=4)
     debug_log('A valid auth-token was found. Proceeding...')
     return content[1]
@@ -123,19 +123,19 @@ def check_streamlink_config():
 def store_auth(data):
     now = int(time.time())
     data['requested_at'] = now - 1
-    if os.path.exists(home_dir + '/qwitch/cache'):
-        with open(home_dir + '/qwitch/cache', 'wr', encoding='utf-8') as file:
+    if os.path.exists(home_dir + '/qwitch/config.json'):
+        with open(home_dir + '/qwitch/config.json', 'wr', encoding='utf-8') as file:
             cache_json = json.loads(file.read())
             cache_json[0] = data
             json.dump(cache_json, file, ensure_ascii=False, indent=4)
     else:
-        with open(home_dir + '/qwitch/cache', 'w', encoding='utf-8') as file:
+        with open(home_dir + '/qwitch/config.json', 'w', encoding='utf-8') as file:
             data = [data]
             json.dump(data, file, ensure_ascii=False, indent=4)
 
 def check_auth():
     try:
-        with open(home_dir + '/qwitch/cache', 'r', encoding='utf-8') as cache:
+        with open(home_dir + '/qwitch/config.json', 'r', encoding='utf-8') as cache:
             cache_json = json.loads(cache.read())
             debug_log('check_auth(): Config read:', cache_json)
         if cache_json:

--- a/qwitch/qwitch.py
+++ b/qwitch/qwitch.py
@@ -14,11 +14,12 @@ def main():
         cli.add_argument('channel', nargs='?', default = False, help= 'channel name given in red with -s/--streams. Needed to launch livestream or videos.')
         cli.add_argument('quality', nargs='?', default = False, help= 'video quality name, e.g. 720p, 1080p, best, worst, etc... (defaults to best). You can defined a default quality in the config file (see the README)')
         cli.add_argument('-d', '--debug', action = 'store_true', help= 'enable debugging.')
-        cli.add_argument('--version', action='version', version='%(prog)s 2.1.0')
+        cli.add_argument('--version', action='version', version='%(prog)s 2.2.0')
 
         group.add_argument('-l', '--last', action = 'store_true', help= 'play the most recent video of the channel.')
         group.add_argument('-V', '--Videos', action = 'store_true', help= 'list the last 20 videos of the channel.')
         group.add_argument('-s', '--streams', action = 'store_true', help= 'list the streamers you follow which are currently currently live.')
+        group.add_argument('-f', '--follows', action = 'store_true', help= 'list the streamers you follow.')
         group.add_argument('-v', '--vod', action = 'store', type = str, help= 'search for a video by keyword(s) or ID. The keyword needs to be in quotation marks and an exact match (this is not a search engine)')
         args = cli.parse_args()
 
@@ -30,7 +31,12 @@ def main():
         if args.debug:
             config.DEBUG = True
 
-        if args.channel:
+        if args.follows:
+            try:
+                api.get_follows(token = auth_token)
+            except:
+                cli.error('Could not get the list of followed streamers.')
+        elif args.channel:
             try:
                 channel_id = api.get_channel_id(channel = args.channel, token = auth_token)
             except RuntimeError:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = qwitch
-version = 2.1.0
+version = 2.2.0
 author = Jean-Francois Vaduret
 author_email = jean.francois.vaduret@gmail.com
 description = Stream twitch in Quicktime.


### PR DESCRIPTION
Closes #5 

This improves the README doc with an `How to use` section and a section on Qwitch's config file.

I also added a `-f/--follows` option to the CLI to list the user's follows. This will allow the users to quickly look up the channel name of the channels they follow.