### PR TITLE
hotfix/store_auth_perm: fix wrong file perm

### DIFF
--- a/qwitch/api.py
+++ b/qwitch/api.py
@@ -111,7 +111,7 @@ def print_vod_list(channel_id, token):
         print('\033[95mPublished on:\033[0m ' + date)
         print('\033[95mDuration:\033[0m     ' + video['duration'])
         print('\033[95mURL:\033[0m          ' + video['url'])
-        print('\033[95mVideo ID:\033[0m          ' + video['id'])
+        print('\033[95mVideo ID:\033[0m     ' + video['id'])
         resp = input('\nPlay this video? [y/N] ')
         if str(resp).lower() == 'y':
             url = video['url'].replace('https://www.', '')

--- a/qwitch/config.py
+++ b/qwitch/config.py
@@ -124,7 +124,7 @@ def store_auth(data):
     now = int(time.time())
     data['requested_at'] = now - 1
     if os.path.exists(home_dir + '/qwitch/config.json'):
-        with open(home_dir + '/qwitch/config.json', 'wr', encoding='utf-8') as file:
+        with open(home_dir + '/qwitch/config.json', 'r+', encoding='utf-8') as file:
             cache_json = json.loads(file.read())
             cache_json[0] = data
             json.dump(cache_json, file, ensure_ascii=False, indent=4)


### PR DESCRIPTION
Fixed asking for `wr` file permission in `config.store_auth()` which doesn't exist.

Also fixed some pagination quirk when showing videos in `api.print_vod_list()`.