### PR TITLE
QWT-16: Print message instead of usage when no streams found

### DIFF
--- a/qwitch/api.py
+++ b/qwitch/api.py
@@ -124,7 +124,9 @@ class TwitchAPI:
                 url += "&user_id=" + follows[i + j]["broadcaster_id"]
                 j += 1
 
-            self.get(url=url)
+            if not self.get(url=url):
+                print("\033[91m\033[1mNo one you follow is currently streaming.\033[0m")
+                return
 
             for video in self.last_data:
                 print("\033[95mStreamer:\033[0m      " + video["user_name"] + " (\033[91m\033[1m" + video["user_login"] + "\033[0m)")

--- a/qwitch/config.py
+++ b/qwitch/config.py
@@ -7,7 +7,7 @@ import time
 import requests
 
 DEBUG = False
-VER = '2.5.0'
+VER = '2.5.1'
 
 home_dir = os.path.expanduser('~')
 home_dir += '/Library/Application Support'


### PR DESCRIPTION
When no one you follow is streaming an errors was raised which made the CLI print a CLI error message with the usage, this can be confusing so I fixed it by printing a nice message when its the case.